### PR TITLE
INT-1008: Updated homebrew deprecated install and uninstall commands

### DIFF
--- a/sh/install.sh
+++ b/sh/install.sh
@@ -45,7 +45,7 @@ function check_homebrew_installed() {
 }
 
 function install_homebrew() {
-    /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
 }
 
 function install_service() {

--- a/sh/uninstall.sh
+++ b/sh/uninstall.sh
@@ -71,7 +71,7 @@ function uninstall_homebrew() {
     if [ $? -eq 0 ]; then
         prompt_user "Uninstall Homebrew installation"
         if [ $? -eq 0 ]; then
-            /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/uninstall.sh)"
+            /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/uninstall.sh)"
         fi
     fi
 }

--- a/sh/uninstall.sh
+++ b/sh/uninstall.sh
@@ -71,7 +71,7 @@ function uninstall_homebrew() {
     if [ $? -eq 0 ]; then
         prompt_user "Uninstall Homebrew installation"
         if [ $? -eq 0 ]; then
-            ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/uninstall)"
+            /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/uninstall.sh)"
         fi
     fi
 }


### PR DESCRIPTION
The existing script uses ruby to install and uninstall homebrew and other packages. Using ruby is deprecated for MacOS.
Updated command to use bash and install & uninstall script paths.