### PR TITLE
Fix proxy failure and telegraf failure in local testing

### DIFF
--- a/Formula/wfproxy.rb
+++ b/Formula/wfproxy.rb
@@ -31,9 +31,8 @@ class Wfproxy < Formula
 
   end
 
-  plist_options :manual => "wfproxy"
-
   service do
+    require_root true
     log_path var/"log/wavefront-proxy/stdout.log"
     error_log_path var/"log/wavefront-proxy/stderr.log"
     keep_alive true

--- a/sh/install.sh
+++ b/sh/install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-IFS=": " read -r _ HOMEBREW_PREFIX <<< "$(brew --config | grep HOMEBREW_PREFIX)"
+HOMEBREW_PREFIX=$(brew --prefix)
 
 TELEGRAF_CONF_FILE=${HOMEBREW_PREFIX}/etc/telegraf.conf
 TELEGRAF_BACKUP_FILE=${HOMEBREW_PREFIX}/etc/telegraf.conf.old

--- a/sh/install.sh
+++ b/sh/install.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+IFS=": " read -r _ HOMEBREW_PREFIX <<< "$(brew --config | grep HOMEBREW_PREFIX)"
+
 TELEGRAF_CONF_FILE=${HOMEBREW_PREFIX}/etc/telegraf.conf
 TELEGRAF_BACKUP_FILE=${HOMEBREW_PREFIX}/etc/telegraf.conf.old
 DEFAULT_TELEGRAF_CONF_FILE=${HOMEBREW_PREFIX}/etc/telegraf.conf.default

--- a/sh/install.sh
+++ b/sh/install.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-HOMEBREW_PREFIX=$(brew --prefix)
-
 TELEGRAF_CONF_FILE=${HOMEBREW_PREFIX}/etc/telegraf.conf
 TELEGRAF_BACKUP_FILE=${HOMEBREW_PREFIX}/etc/telegraf.conf.old
 DEFAULT_TELEGRAF_CONF_FILE=${HOMEBREW_PREFIX}/etc/telegraf.conf.default


### PR DESCRIPTION
This addresses an issue that we encountered trying to address the original bug report.
1. It seems that with Brew 4.1.0, `plist_options` is disabled, and meant to be replaced with `service.require_root`. I made this change in `wfproxy.rb` to allow testing, but wasn't sure which of the other Formulas it should be made in. The fix does seem to work correctly.